### PR TITLE
Fix order of tasks in webserver role to help users get out of a mess.

### DIFF
--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -8,14 +8,14 @@
     - httpd
     - mod_ssl
 
-- name: Ensure apache is running
-  service:
-    name: httpd
-    state: started
-    enabled: yes
-
 - name: Configure a VirtualHost
   copy:
     src: etc/httpd/conf.d/ansibletest.conf
     dest: /etc/httpd/conf.d/ansibletest.conf
   notify: apache restart
+
+- name: Ensure apache is running
+  service:
+    name: httpd
+    state: started
+    enabled: yes


### PR DESCRIPTION
A couple users ran into an issue where the webserver role would fail on the 'Ensure apache is running' task because the virtualhost had an error in it (e.g. wrong hostname, something like that). Switching the order of these two tasks makes it work correctly and bails the user out in case they broke things the first time around.