### PR TITLE
Adding requirements.yml file to project

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,3 +4,4 @@ ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/
 inventory = ./inventory/
 host_key_checking = False
 
+roles_path = roles/

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,7 @@
+---
+# ansible requirements file
+#
+# ansible-galaxy install -r requirements.yml
+
+# Install a role from the Ansible Galaxy
+- src: geerlingguy.certbot


### PR DESCRIPTION
Adding requirements.yml file to install required geerlingguy.certbot Ansible Galaxy role in the local repository roles folder. User must run command `ansible-galaxy install -r requirements.yml` to install role. This will help by not requiring the user to add the role to the global ansible roles folder.